### PR TITLE
No longer using the deprecated gulp-util package, closes #53

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,12 @@
     "css"
   ],
   "dependencies": {
-    "gulp-util": "^3.0.7",
     "is-fn": "^1.0.0",
+    "plugin-error": "^1.0.1",
     "rework": "^1.0.1",
     "rework-plugin-url": "^1.0.1",
     "through2": "^2.0.3",
+    "vinyl": "^2.1.0",
     "vinyl-sourcemaps-apply": "^0.2.1"
   },
   "devDependencies": {
@@ -50,9 +51,9 @@
     "gulp": "^3.9.0",
     "gulp-babel": "^7.0.0",
     "gulp-eslint": "^4.0.0",
-    "gulp-file": "^0.3.0",
+    "gulp-file": "^0.4.0",
     "gulp-istanbul": "^1.0.0",
-    "gulp-mocha": "^4.3.1",
+    "gulp-mocha": "^5.0.0",
     "gulp-sourcemaps": "^2.6.1",
     "semantic-release": "^4.3.5"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import applySourceMap from 'vinyl-sourcemaps-apply'
-import gutil from 'gulp-util'
+import PluginError from 'plugin-error'
 import isFn from 'is-fn'
 import rework from 'rework'
 import reworkUrl from 'rework-plugin-url'
@@ -67,6 +67,6 @@ module.exports = options =>
 
       return cb()
     } catch (e) {
-      return cb(new gutil.PluginError('modify-css-urls', e))
+      return cb(new PluginError('modify-css-urls', e))
     }
   })

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,8 @@
 import assert from 'assert'
 import gulp from 'gulp'
 import gFile from 'gulp-file'
-import gutil from 'gulp-util'
+import Vinyl from 'vinyl'
+import PluginError from 'plugin-error'
 import sourcemaps from 'gulp-sourcemaps'
 
 import modifyCssUrls from '../lib'
@@ -18,7 +19,7 @@ describe('gulp-modify-css-urls', () => {
     ].join('')
   })
 
-  it('should not change anything in fileContents if no option set', done => {
+  it('should not change anypring in fileContents if no option set', done => {
     stream = modifyCssUrls()
 
     stream.on('data', file => {
@@ -26,7 +27,7 @@ describe('gulp-modify-css-urls', () => {
       done()
     })
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       base: '.',
       path: './style.css',
       contents: Buffer.from(fileContents)
@@ -43,12 +44,12 @@ describe('gulp-modify-css-urls', () => {
     })
 
     stream.on('error', error => {
-      assert(error instanceof gutil.PluginError)
+      assert(error instanceof PluginError)
       assert(error.plugin === 'modify-css-urls')
       done()
     })
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       base: '.',
       path: './style.css',
       contents: Buffer.from('invalid css')
@@ -78,7 +79,7 @@ describe('gulp-modify-css-urls', () => {
       done()
     })
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       base: '.',
       path: './style.css',
       contents: Buffer.from(fileContents)
@@ -93,7 +94,7 @@ describe('gulp-modify-css-urls', () => {
     stream.on('data', file => {
       const expectedCss = [
         'body {\n',
-        '  background-image: url("app/./style.cssimages/logo.png");\n',
+        '  background-image: url("app/style.cssimages/logo.png");\n',
         '}'
       ].join('')
 
@@ -101,7 +102,7 @@ describe('gulp-modify-css-urls', () => {
       done()
     })
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       base: '.',
       path: './style.css',
       contents: Buffer.from(fileContents)
@@ -126,7 +127,7 @@ describe('gulp-modify-css-urls', () => {
       done()
     })
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       base: '.',
       path: './style.css',
       contents: Buffer.from(fileContents)
@@ -151,7 +152,7 @@ describe('gulp-modify-css-urls', () => {
       done()
     })
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       base: '.',
       path: './style.css',
       contents: Buffer.from(fileContents)
@@ -176,7 +177,7 @@ describe('gulp-modify-css-urls', () => {
       done()
     })
 
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
       base: '.',
       path: './style.css',
       contents: Buffer.from(fileContentsWithDataURI)


### PR DESCRIPTION
I also updated some packages that relied on old gulp-util. I did not update gulp (to 4.0.0) though as it is still not officially released.